### PR TITLE
Check if template view exists.

### DIFF
--- a/Http/Controllers/PublicController.php
+++ b/Http/Controllers/PublicController.php
@@ -59,7 +59,7 @@ class PublicController extends BasePublicController
      */
     private function getTemplateForPage($page)
     {
-        return $page->template ?: 'default';
+        return (view()->exists($page->template)) ? $page->template : 'default';
     }
 
     /**


### PR DESCRIPTION
Instead of checking if there’s a template value for a page, check to
see if there’s a view for the specified template. This will prevent
errors when there’s a template value set for a page, but no
corresponding view.
