### PR TITLE
Remove duplicate ckeditor insertion

### DIFF
--- a/Resources/views/admin/create.blade.php
+++ b/Resources/views/admin/create.blade.php
@@ -12,7 +12,6 @@
 @stop
 
 @section('styles')
-    {!! Theme::script('js/vendor/ckeditor/ckeditor.js') !!}
     <style>
         .checkbox label {
             padding-left: 0;
@@ -87,16 +86,6 @@
 @stop
 
 @section('scripts')
-    <script type="text/javascript">
-        $(function() {
-            /*CKEDITOR.replaceAll(function( textarea, config ) {
-                if (!$(textarea).hasClass('ckeditor')) {
-                    return false;
-                }
-                config.language = '<?php echo App::getLocale() ?>';
-            } );*/
-        });
-    </script>
     <script>
         $( document ).ready(function() {
             $(document).keypressAction({

--- a/Resources/views/admin/edit.blade.php
+++ b/Resources/views/admin/edit.blade.php
@@ -12,7 +12,6 @@
 @stop
 
 @section('styles')
-    {!! Theme::script('js/vendor/ckeditor/ckeditor.js') !!}
     <style>
         .checkbox label {
             padding-left: 0;
@@ -88,16 +87,6 @@
 @stop
 
 @section('scripts')
-    <script type="text/javascript">
-        $(function() {
-           /* CKEDITOR.replaceAll(function( textarea, config ) {
-                if (!$(textarea).hasClass('ckeditor')) {
-                    return false;
-                }
-                config.language = '<?php echo App::getLocale() ?>';
-            } );*/
-        });
-    </script>
     <script>
         $( document ).ready(function() {
             $(document).keypressAction({


### PR DESCRIPTION
ckeditor is inserted twice. This also prevents overriding ckeditor with something like : 
`$this->assetPipeline->requireJs('ckeditor-full.js')->before('ckeditor.js');`

I also deleted useless commented code.
